### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
   "name": "welbinator/youtube-for-wordpress-pro",
   "description": "YouTube for WordPress Pro",
   "type": "wordpress-plugin",
+  "require": {
+    "sentry/sentry": "^4.25"
+  },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.9",
     "wp-coding-standards/wpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,620 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c96da3c1763418d68960aca9dbdfe21c",
-    "packages": [],
+    "content-hash": "2a6afe276511842f4ac6fe118a00bd98",
+    "packages": [
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-10T16:41:02+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "sentry/sentry",
+            "version": "4.25.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "bfee3381e1f6dea8a5f3a18adba6419fe81c5f54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/bfee3381e1f6dea8a5f3a18adba6419fe81c5f54",
+                "reference": "bfee3381e1f6dea8a5f3a18adba6419fe81c5f54",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/psr7": "^1.8.4|^2.1.1",
+                "jean85/pretty-package-versions": "^1.5|^2.0.4",
+                "php": "^7.2|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "guzzlehttp/promises": "^2.0.3",
+                "guzzlehttp/psr7": "^1.8.4|^2.1.1",
+                "monolog/monolog": "^1.6|^2.0|^3.0",
+                "nyholm/psr7": "^1.8",
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/exporter-otlp": "^1.0",
+                "open-telemetry/sdk": "^1.0",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^8.5.52|^9.6.34",
+                "spiral/roadrunner-http": "^3.6",
+                "spiral/roadrunner-worker": "^3.6"
+            },
+            "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+                "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Sentry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sentry",
+                    "email": "accounts@sentry.io"
+                }
+            ],
+            "description": "PHP SDK for Sentry (http://sentry.io)",
+            "homepage": "http://sentry.io",
+            "keywords": [
+                "crash-reporting",
+                "crash-reports",
+                "error-handler",
+                "error-monitoring",
+                "log",
+                "logging",
+                "profiling",
+                "sentry",
+                "tracing"
+            ],
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-php/issues",
+                "source": "https://github.com/getsentry/sentry-php/tree/4.25.0"
+            },
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-04-23T12:50:03+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/includes/admin-settings.php
+++ b/includes/admin-settings.php
@@ -309,6 +309,42 @@ function register_settings() {
 	);
 
 	// Channel ID is now managed via the Channels page.
+
+	// Register Sentry error reporting opt-in setting.
+	add_settings_field(
+		'yt_for_wp_sentry_optin',
+		__( 'Error Reporting', 'yt-for-wp-pro' ),
+		function () {
+			$optin = get_option( 'yt_for_wp_sentry_optin', '' );
+			?>
+			<label>
+				<input
+					type="checkbox"
+					name="yt_for_wp_sentry_optin"
+					value="1"
+					<?php checked( '1', $optin ); ?>
+				/>
+				<?php esc_html_e( 'Help improve this plugin by sending anonymous error reports', 'yt-for-wp-pro' ); ?>
+			</label>
+			<p class="description">
+				<?php esc_html_e( 'When enabled, PHP errors and exceptions are sent to Sentry to help us identify and fix bugs. No personal data is collected.', 'yt-for-wp-pro' ); ?>
+			</p>
+			<?php
+		},
+		'yt-for-wp-settings',
+		'yt_for_wp_main_section'
+	);
+
+	register_setting(
+		'yt_for_wp_settings',
+		'yt_for_wp_sentry_optin',
+		array(
+			'sanitize_callback' => function ( $input ) {
+				return $input ? '1' : '0';
+			},
+			'show_in_rest'      => false,
+		)
+	);
 }
 add_action( 'admin_init', __NAMESPACE__ . '\\register_settings' );
 
@@ -324,16 +360,6 @@ function render_settings_page() {
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'YouTube for WordPress Settings', 'yt-for-wp-pro' ); ?></h1>
-
-		<?php if ( ! defined( 'YT_FOR_WP_ENCRYPTION_KEY' ) ) : ?>
-		<div class="notice notice-info">
-			<p>
-				<strong><?php esc_html_e( 'Security tip:', 'yt-for-wp-pro' ); ?></strong>
-				<?php esc_html_e( 'For stronger API key protection, add the following line to your wp-config.php. This stores the encryption key outside the database so it cannot be used even if your database is compromised.', 'yt-for-wp-pro' ); ?>
-			</p>
-			<p><code>define( 'YT_FOR_WP_ENCRYPTION_KEY', '<?php echo esc_html( wp_generate_password( 32, true, true ) ); ?>' );</code></p>
-		</div>
-		<?php endif; ?>
 
 		<?php
 		settings_errors( 'yt_for_wp_api_key' );
@@ -354,6 +380,42 @@ function render_settings_page() {
 			?>
 		</form>
 	</div>
+
+	<?php if ( ! get_option( 'yt_for_wp_sentry_modal_shown' ) ) : ?>
+	<div id="yt-for-wp-sentry-modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:99999; align-items:center; justify-content:center;">
+		<div style="background:#fff; border-radius:4px; padding:32px; max-width:480px; width:90%; box-shadow:0 4px 24px rgba(0,0,0,.2);">
+			<h2 style="margin-top:0;"><?php esc_html_e( 'Help Us Improve', 'yt-for-wp-pro' ); ?></h2>
+			<p><?php esc_html_e( 'Would you like to help improve YouTube for WordPress Pro by sending anonymous error reports? This helps us identify and fix bugs faster.', 'yt-for-wp-pro' ); ?></p>
+			<p style="font-size:12px; color:#666;"><?php esc_html_e( 'No personal data is collected. You can change this at any time in the settings below.', 'yt-for-wp-pro' ); ?></p>
+			<div style="display:flex; gap:12px; margin-top:24px;">
+				<button id="yt-sentry-optin-yes" class="button button-primary"><?php esc_html_e( 'Yes, I\'ll help!', 'yt-for-wp-pro' ); ?></button>
+				<button id="yt-sentry-optin-no" class="button"><?php esc_html_e( 'No thanks', 'yt-for-wp-pro' ); ?></button>
+			</div>
+		</div>
+	</div>
+	<script>
+	(function() {
+		var modal = document.getElementById('yt-for-wp-sentry-modal');
+		if (!modal) return;
+		modal.style.display = 'flex';
+
+		function dismissModal(optin) {
+			modal.style.display = 'none';
+			var data = new FormData();
+			data.append('action', 'yt_for_wp_sentry_modal_response');
+			data.append('optin', optin ? '1' : '0');
+			data.append('nonce', '<?php echo esc_js( wp_create_nonce( 'yt-for-wp-sentry-modal' ) ); ?>');
+			fetch('<?php echo esc_js( admin_url( 'admin-ajax.php' ) ); ?>', { method: 'POST', body: data });
+			// Update checkbox to match choice.
+			var cb = document.querySelector('input[name="yt_for_wp_sentry_optin"]');
+			if (cb) cb.checked = !!optin;
+		}
+
+		document.getElementById('yt-sentry-optin-yes').addEventListener('click', function() { dismissModal(true); });
+		document.getElementById('yt-sentry-optin-no').addEventListener('click', function() { dismissModal(false); });
+	})();
+	</script>
+	<?php endif; ?>
 	<?php
 }
 
@@ -448,3 +510,22 @@ function validate_api_key( $api_key ) {
 
 	return __( 'API Key Valid.', 'yt-for-wp-pro' );
 }
+
+/**
+ * Handle the Sentry opt-in modal AJAX response.
+ * Saves the user's choice and marks the modal as shown (never show again).
+ */
+function handle_sentry_modal_response() {
+	check_ajax_referer( 'yt-for-wp-sentry-modal', 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( 'Insufficient permissions.' );
+	}
+
+	$optin = isset( $_POST['optin'] ) && '1' === $_POST['optin'] ? '1' : '0';
+	update_option( 'yt_for_wp_sentry_optin', $optin );
+	update_option( 'yt_for_wp_sentry_modal_shown', '1' );
+
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_yt_for_wp_sentry_modal_response', __NAMESPACE__ . '\\handle_sentry_modal_response' );

--- a/includes/pro-settings.php
+++ b/includes/pro-settings.php
@@ -547,7 +547,7 @@ echo \'<iframe src="\' . esc_url( $embed_url ) . \'" allowfullscreen></iframe>\'
 		?>
 																												</pre>
 
-		<h3><?php esc_html_e( 'Querying videos by post type', 'yt-for-wp-pro' ); ?></h3>
+		<h2><?php esc_html_e( 'Querying videos by post type', 'yt-for-wp-pro' ); ?></h2>
 		<p>
 			<?php
 			$post_types = \YouTubeForWPPro\VideoCPT\Video_Post_Type::get_all();
@@ -577,6 +577,14 @@ $videos = new WP_Query( [
 		?>
 																												</pre>
 
+		<h2><?php esc_html_e( 'Security: Protecting Your API Key', 'yt-for-wp-pro' ); ?></h2>
+		<p><?php esc_html_e( 'By default, your YouTube API key is stored encrypted in the WordPress database. For stronger protection, you can move the encryption key out of the database entirely by defining it in your wp-config.php file. This way, even if your database is compromised, the key cannot be decrypted without also having access to your server files.', 'yt-for-wp-pro' ); ?></p>
+		<p><?php esc_html_e( 'Add the following line to your wp-config.php (before the line that says "That\'s all, stop editing!"):', 'yt-for-wp-pro' ); ?></p>
+		<pre style="background:#f6f7f7; padding:16px; border:1px solid #ddd; max-width:800px; overflow-x:auto;"><?php echo esc_html( "define( 'YT_FOR_WP_ENCRYPTION_KEY', 'your-random-32-character-string-here' );" ); ?></pre>
+		<p><?php esc_html_e( 'Replace the placeholder with a unique random string of at least 32 characters. You can generate one at', 'yt-for-wp-pro' ); ?> <a href="https://api.wordpress.org/secret-key/1.1/salt/" target="_blank">api.wordpress.org/secret-key</a>.</p>
+		<p><strong><?php esc_html_e( 'Important:', 'yt-for-wp-pro' ); ?></strong> <?php esc_html_e( 'If you add this constant after already saving an API key, you will need to re-enter your API key in Settings so it gets re-encrypted with the new key.', 'yt-for-wp-pro' ); ?></p>
+
 	</div>
 	<?php
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-for-wordpress-pro",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "main": "index.js",
   "scripts": {
     "start": "wp-scripts start",

--- a/youtube-for-wordpress-pro.php
+++ b/youtube-for-wordpress-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: YouTube for WordPress Pro
  * Plugin URI: https://jameswelbes.com/youtube-for-wordpress
  * Description: A complete toolkit for integrating YouTube functionalities into WordPress with premium features.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: James Welbes
@@ -19,6 +19,25 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+// Initialize Sentry error tracking (only if user has opted in).
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+	add_action(
+		'plugins_loaded',
+		function () {
+			if ( '1' === get_option( 'yt_for_wp_sentry_optin' ) ) {
+				\Sentry\init( [
+					'dsn'                  => 'https://ba957d80d0d1600a985f780cf29bc59e@o4511277283409920.ingest.us.sentry.io/4511277284851712',
+					'traces_sample_rate'   => 1.0,
+					'profiles_sample_rate' => 1.0,
+					'enable_logs'          => true,
+				] );
+			}
+		},
+		1
+	);
 }
 
 // Include plugin.php for is_plugin_active() and deactivate_plugins().
@@ -69,12 +88,12 @@ if ( defined( 'YOUTUBE_FOR_WP_ACTIVE' ) && defined( 'YT_FOR_WP_PATH' ) && YT_FOR
 
 // Define plugin constants for Pro version.
 define( 'YOUTUBEFORWORDPRESS_PRO', __FILE__ );
-define( 'YOUTUBE_FOR_WP_PRO_VERSION', '2.1.0' );
+define( 'YOUTUBE_FOR_WP_PRO_VERSION', '2.1.1' );
 define( 'YT_FOR_WP_PRO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'YT_FOR_WP_PRO_URL', plugin_dir_url( __FILE__ ) );
 
 // Define constants for core functionality (formerly free plugin).
-define( 'YOUTUBE_FOR_WP_VERSION', '2.1.0' );
+define( 'YOUTUBE_FOR_WP_VERSION', '2.1.1' );
 define( 'YT_FOR_WP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'YT_FOR_WP_URL', plugin_dir_url( __FILE__ ) );
 define( 'YT_FOR_WP_MIN_WP_VERSION', '5.8' );


### PR DESCRIPTION
Bumps plugin version to 2.1.1. Also includes Sentry error tracking integration (opt-in), security tip moved from settings to help page, and encryption key section added to help page.