### PR TITLE
fix: preserve block builds during npm build, regenerate phpstan baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "wp-scripts start",
     "copy-swiper-css": "mkdir -p build/css && cp node_modules/swiper/swiper-bundle.min.css build/css/",
-    "build": "wp-scripts build && npm run copy-swiper-css"
+    "prebuild": "cp -r build/simple-youtube-feed /tmp/yt-block-syf 2>/dev/null; cp -r build/youtube-live /tmp/yt-block-live 2>/dev/null; cp -r build/css /tmp/yt-block-css 2>/dev/null; true",
+    "build": "wp-scripts build && npm run copy-swiper-css",
+    "postbuild": "cp -r /tmp/yt-block-syf build/simple-youtube-feed 2>/dev/null; cp -r /tmp/yt-block-live build/youtube-live 2>/dev/null; true"
   },
   "author": "James Welbes",
   "license": "GPL-2.0-or-later",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -132,12 +132,12 @@ parameters:
 
 		-
 			message: "#^Function __ not found\\.$#"
-			count: 13
+			count: 14
 			path: includes/admin-settings.php
 
 		-
 			message: "#^Function add_action not found\\.$#"
-			count: 1
+			count: 2
 			path: includes/admin-settings.php
 
 		-
@@ -157,7 +157,7 @@ parameters:
 
 		-
 			message: "#^Function add_settings_field not found\\.$#"
-			count: 1
+			count: 2
 			path: includes/admin-settings.php
 
 		-
@@ -166,8 +166,23 @@ parameters:
 			path: includes/admin-settings.php
 
 		-
+			message: "#^Function admin_url not found\\.$#"
+			count: 1
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function check_ajax_referer not found\\.$#"
+			count: 1
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function checked not found\\.$#"
+			count: 1
+			path: includes/admin-settings.php
+
+		-
 			message: "#^Function current_user_can not found\\.$#"
-			count: 6
+			count: 7
 			path: includes/admin-settings.php
 
 		-
@@ -187,7 +202,7 @@ parameters:
 
 		-
 			message: "#^Function esc_html not found\\.$#"
-			count: 2
+			count: 1
 			path: includes/admin-settings.php
 
 		-
@@ -197,12 +212,17 @@ parameters:
 
 		-
 			message: "#^Function esc_html_e not found\\.$#"
-			count: 4
+			count: 9
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function esc_js not found\\.$#"
+			count: 2
 			path: includes/admin-settings.php
 
 		-
 			message: "#^Function get_option not found\\.$#"
-			count: 3
+			count: 5
 			path: includes/admin-settings.php
 
 		-
@@ -217,7 +237,7 @@ parameters:
 
 		-
 			message: "#^Function register_setting not found\\.$#"
-			count: 1
+			count: 2
 			path: includes/admin-settings.php
 
 		-
@@ -242,16 +262,16 @@ parameters:
 
 		-
 			message: "#^Function update_option not found\\.$#"
+			count: 3
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function wp_create_nonce not found\\.$#"
 			count: 1
 			path: includes/admin-settings.php
 
 		-
 			message: "#^Function wp_die not found\\.$#"
-			count: 1
-			path: includes/admin-settings.php
-
-		-
-			message: "#^Function wp_generate_password not found\\.$#"
 			count: 1
 			path: includes/admin-settings.php
 
@@ -267,6 +287,16 @@ parameters:
 
 		-
 			message: "#^Function wp_remote_retrieve_body not found\\.$#"
+			count: 1
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function wp_send_json_error not found\\.$#"
+			count: 1
+			path: includes/admin-settings.php
+
+		-
+			message: "#^Function wp_send_json_success not found\\.$#"
 			count: 1
 			path: includes/admin-settings.php
 
@@ -622,7 +652,7 @@ parameters:
 
 		-
 			message: "#^Function esc_html not found\\.$#"
-			count: 16
+			count: 17
 			path: includes/pro-settings.php
 
 		-
@@ -632,7 +662,7 @@ parameters:
 
 		-
 			message: "#^Function esc_html_e not found\\.$#"
-			count: 56
+			count: 62
 			path: includes/pro-settings.php
 
 		-
@@ -892,7 +922,7 @@ parameters:
 
 		-
 			message: "#^Function add_action not found\\.$#"
-			count: 12
+			count: 13
 			path: youtube-for-wordpress-pro.php
 
 		-
@@ -952,7 +982,7 @@ parameters:
 
 		-
 			message: "#^Function get_option not found\\.$#"
-			count: 12
+			count: 13
 			path: youtube-for-wordpress-pro.php
 
 		-

--- a/youtube-for-wordpress-pro.php
+++ b/youtube-for-wordpress-pro.php
@@ -28,12 +28,14 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 		'plugins_loaded',
 		function () {
 			if ( '1' === get_option( 'yt_for_wp_sentry_optin' ) ) {
-				\Sentry\init( [
-					'dsn'                  => 'https://ba957d80d0d1600a985f780cf29bc59e@o4511277283409920.ingest.us.sentry.io/4511277284851712',
-					'traces_sample_rate'   => 1.0,
-					'profiles_sample_rate' => 1.0,
-					'enable_logs'          => true,
-				] );
+				\Sentry\init(
+					array(
+						'dsn'                  => 'https://ba957d80d0d1600a985f780cf29bc59e@o4511277283409920.ingest.us.sentry.io/4511277284851712',
+						'traces_sample_rate'   => 1.0,
+						'profiles_sample_rate' => 1.0,
+						'enable_logs'          => true,
+					)
+				);
 			}
 		},
 		1


### PR DESCRIPTION
Fixes CI failures introduced by PR #22:\n- Added prebuild/postbuild scripts to back up and restore block build files that wp-scripts was deleting\n- Regenerated PHPStan baseline to match the new code added in 2.2.0