### PR TITLE
fix: updater integrity check must never block theme or other plugin installs

### DIFF
--- a/github-update.php
+++ b/github-update.php
@@ -119,8 +119,13 @@ function check_for_updates( $transient ) {
  * @return bool|WP_Error False to proceed, WP_Error to abort.
  */
 function verify_package_integrity( $reply, $package, $upgrader ) {
-	// Only act on our plugin's package.
-	if ( ! isset( $upgrader->skin->plugin_info ) ) {
+	// Only act on our plugin's package URL — never block theme or other plugin installs.
+	if ( empty( $package ) || false === strpos( $package, 'youtube-for-wordpress-pro' ) ) {
+		return $reply;
+	}
+
+	// Also confirm this is a plugin upgrader, not a theme upgrader.
+	if ( ! ( $upgrader instanceof \Plugin_Upgrader ) ) {
 		return $reply;
 	}
 


### PR DESCRIPTION
The `verify_package_integrity` hook was firing for ALL WordPress installs/updates, not just ours. This adds two guards:\n\n1. **Package URL check** — if the URL doesn't contain 'youtube-for-wordpress-pro', bail immediately\n2. **Upgrader type check** — if it's not a Plugin_Upgrader instance (e.g. it's a Theme_Upgrader), bail immediately\n\nThis ensures our integrity check can never block theme installs or unrelated plugin updates, regardless of release issues on our end.